### PR TITLE
Allow setting custom credentials for token auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/gophercloud/utils
 
+replace github.com/gophercloud/gophercloud => /home/xagent/gophercloud
+
 require (
 	github.com/gophercloud/gophercloud v1.3.0
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/gophercloud/gophercloud v1.3.0 h1:RUKyCMiZoQR3VlVR5E3K7PK1AC3/qppsWYo6dtBiqs8=
-github.com/gophercloud/gophercloud v1.3.0/go.mod h1:aAVqcocTSXh2vYFZ1JTvx4EQmfgzxRcNupUfxZbBNDM=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=

--- a/openstack/clientconfig/requests.go
+++ b/openstack/clientconfig/requests.go
@@ -32,6 +32,9 @@ const (
 	// AuthV2Token defines version 2 of the token
 	AuthV2Token AuthType = "v2token"
 
+	// AuthV2APIKey defines a rackspace API key
+	AuthV2CustomCredential AuthType = "customCredential"
+
 	// AuthV3Password defines version 3 of the password
 	AuthV3Password AuthType = "v3password"
 	// AuthV3Token defines version 3 of the token
@@ -436,6 +439,8 @@ func determineIdentityAPI(cloud *Cloud, opts *ClientOpts) string {
 			identityAPI = "2.0"
 		case AuthV2Token:
 			identityAPI = "2.0"
+		case AuthV2CustomCredential:
+			identityAPI = "2.0"
 		case AuthV3Password:
 			identityAPI = "3"
 		case AuthV3Token:
@@ -510,6 +515,12 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		}
 	}
 
+	if cloud.AuthInfo.CustomCredential == "" {
+		if v := env.Getenv(envPrefix + "CUSTOM_CREDENTIAL"); v != "" {
+			cloud.AuthInfo.CustomCredential = v
+		}
+	}
+
 	ao := &gophercloud.AuthOptions{
 		IdentityEndpoint: cloud.AuthInfo.AuthURL,
 		TokenID:          cloud.AuthInfo.Token,
@@ -518,6 +529,7 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		TenantID:         cloud.AuthInfo.ProjectID,
 		TenantName:       cloud.AuthInfo.ProjectName,
 		AllowReauth:      cloud.AuthInfo.AllowReauth,
+		CustomCredential: cloud.AuthInfo.CustomCredential,
 	}
 
 	return ao, nil

--- a/openstack/clientconfig/results.go
+++ b/openstack/clientconfig/results.go
@@ -136,6 +136,9 @@ type AuthInfo struct {
 	// false, it will not cache these settings, but re-authentication will not be
 	// possible.  This setting defaults to false.
 	AllowReauth bool `yaml:"allow_reauth,omitempty" json:"allow_reauth,omitempty"`
+
+	// APIKey defines an API Key based auth as opposed to password which does not work with 2FA
+	CustomCredential string `yaml:"custom_credential,omitempty" json:"custom_credential,omitempty"`
 }
 
 // Region represents a region included as part of cloud in clouds.yaml


### PR DESCRIPTION
Allows using the Rackspace API Key to set a custom credential with gophercloud. Since this is Rackspace specific: 

1. form the Json body of the Rackspace auth as a raw JSON message, and
2. Update gophercloud/utils and gophercloud/gophercloud to take in a custom auth format instead of password/token

Also depends on: https://github.com/platform9/gophercloud/pull/1 and https://github.com/platform9/cloud-provider-rackspace/pull/1